### PR TITLE
スマホUIのトップページ空白調整

### DIFF
--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -12,7 +12,7 @@ export default function ClientLayout({
   return (
     <SupabaseAuthProvider>
       <Header />
-      <main className="pt-20">
+      <main className="pt-16 md:pt-20">
         {children}
       </main>
     </SupabaseAuthProvider>

--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -12,7 +12,7 @@ export default function ClientLayout({
   return (
     <SupabaseAuthProvider>
       <Header />
-      <main className="pt-16 md:pt-20">
+      <main className="pt-12 md:pt-20">
         {children}
       </main>
     </SupabaseAuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,10 @@ export default function Home() {
   return (
     <main className="min-h-screen">
       {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center justify-center px-6 py-8 md:py-12 lg:py-24">
-        <div className="max-w-6xl mx-auto text-center space-y-12 md:space-y-16">
+      <section className="relative min-h-screen flex items-center justify-center px-6 py-4 md:py-12 lg:py-24">
+        <div className="max-w-6xl mx-auto text-center space-y-8 md:space-y-12 lg:space-y-16">
           {/* メインタイトル */}
-          <div className="space-y-6 md:space-y-8 fade-in">
+          <div className="space-y-4 md:space-y-6 lg:space-y-8 fade-in">
             <h1 className="text-4xl md:text-5xl lg:text-7xl font-bold text-ios-gray-800 leading-tight">
               あなたにぴったりの
               <span className="holographic-text block">一冊を見つけよう</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <main className="min-h-screen">
       {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center justify-center px-6 py-12 md:py-24">
+      <section className="relative min-h-screen flex items-center justify-center px-6 py-8 md:py-12 lg:py-24">
         <div className="max-w-6xl mx-auto text-center space-y-12 md:space-y-16">
           {/* メインタイトル */}
           <div className="space-y-6 md:space-y-8 fade-in">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-40 bg-white/80 backdrop-blur-md border-b border-ios-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-4">
+        <div className="max-w-7xl mx-auto px-4 py-3 md:py-4">
           <div className="flex justify-between items-center">
             {/* ロゴ */}
             <Link href="/" className="text-2xl font-bold text-ios-gray-800">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-40 bg-white/80 backdrop-blur-md border-b border-ios-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-3 md:py-4">
+        <div className="max-w-7xl mx-auto px-4 py-2 md:py-4">
           <div className="flex justify-between items-center">
             {/* ロゴ */}
             <Link href="/" className="text-2xl font-bold text-ios-gray-800">


### PR DESCRIPTION
Reduce excessive top padding and header height on mobile to eliminate unnatural white space above the "あなたにぴったりの一冊を見つけよう" section.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ccb539c-8b14-487f-8cff-2a8a39b2c905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ccb539c-8b14-487f-8cff-2a8a39b2c905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

