### PR TITLE
書籍カードの読みやすさと難易度閾値を設定

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,14 +16,14 @@ export function getReadabilityLevel(pageCount: number): {
   description: string;
   color: string;
 } {
-  if (pageCount <= 200) {
+  if (pageCount <= 300) {
     return {
       level: 'easy',
       label: '読みやすい',
       description: '気軽に読める分量',
       color: 'text-ios-green'
     };
-  } else if (pageCount <= 400) {
+  } else if (pageCount <= 600) {
     return {
       level: 'moderate',
       label: '少し頑張る',


### PR DESCRIPTION
Update book card readability thresholds to reflect user's preference for 300 pages as the "easy" boundary.

The user requested to set the threshold for "読みやすい" (readable) and "少し頑張る" (need some effort) to 300 pages. This change adjusts the "readable" category to include books up to 300 pages and consequently shifts the "need some effort" and "serious reading" categories to higher page counts to maintain logical progression.

---
<a href="https://cursor.com/background-agent?bcId=bc-896074e4-eca9-4efb-aa05-ebb12cd51416">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-896074e4-eca9-4efb-aa05-ebb12cd51416">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

