### PR TITLE
Improve top page text visibility and add PR to Amazon links

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1094,7 +1094,7 @@ export default function AdminPage() {
                                rel="noopener noreferrer" 
                                className="underline hover:no-underline font-medium"
                              >
-                               Amazon PR
+                               Amazon (PR)
                              </a>
                            </div>
                          )}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1094,7 +1094,7 @@ export default function AdminPage() {
                                rel="noopener noreferrer" 
                                className="underline hover:no-underline font-medium"
                              >
-                               Amazon
+                               Amazon PR
                              </a>
                            </div>
                          )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,7 @@ export default function Home() {
           </ScrollAnimatedSection>
           
           <ScrollAnimatedSection animationType="fade-in" delay={200}>
-            <p className="text-xl font-light opacity-90 max-w-2xl mx-auto leading-relaxed">
+            <p className="text-xl font-light text-white max-w-2xl mx-auto leading-relaxed">
               たった1分で、あなたの人生を変える一冊に出会えるかもしれません。
             </p>
           </ScrollAnimatedSection>

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -252,7 +252,7 @@ function ResultsContent() {
                       }}
                     >
                       <Button variant="primary" className="w-full text-sm">
-                        📚 Amazon PR
+                        📚 Amazon (PR)
                       </Button>
                     </a>
                     {result.book.summary_link ? (

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -252,7 +252,7 @@ function ResultsContent() {
                       }}
                     >
                       <Button variant="primary" className="w-full text-sm">
-                        📚 Amazon
+                        📚 Amazon PR
                       </Button>
                     </a>
                     {result.book.summary_link ? (

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -474,7 +474,7 @@ export default function SearchPage() {
                           }}
                           className="flex-1"
                         >
-                          📚 Amazon PR
+                          📚 Amazon (PR)
                         </Button>
                       </div>
                     </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -474,7 +474,7 @@ export default function SearchPage() {
                           }}
                           className="flex-1"
                         >
-                          📚 Amazon
+                          📚 Amazon PR
                         </Button>
                       </div>
                     </div>

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -52,7 +52,7 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
           <h2 className="text-3xl font-bold text-ios-gray-800 mb-8">{title}</h2>
           <div className="flex gap-4 overflow-hidden">
             {Array.from({ length: count }).map((_, index) => (
-              <div key={index} className="flex-shrink-0 w-64 h-[440px] bg-ios-gray-100 rounded-2xl animate-pulse"></div>
+              <div key={index} className="flex-shrink-0 w-64 h-[500px] bg-ios-gray-100 rounded-2xl animate-pulse"></div>
             ))}
           </div>
         </div>
@@ -89,15 +89,14 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                 className="flex-shrink-0 w-64 snap-start hover-lift"
                 style={{ animationDelay: `${index * 0.1}s` }}
               >
-                <div className="bg-white rounded-2xl shadow-ios hover:shadow-ios-lg transition-all duration-300 overflow-hidden flex flex-col h-[440px]">
+                <div className="bg-white rounded-2xl shadow-ios hover:shadow-ios-lg transition-all duration-300 overflow-hidden flex flex-col h-[500px]">
                   {/* 書籍画像 */}
                   <div className="w-full h-40 bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 flex items-center justify-center overflow-hidden">
                     {book.cover_image_url ? (
                       <img
                         src={book.cover_image_url}
                         alt={book.title}
-                        className="max-w-full max-h-full object-contain"
-                        style={{ width: 'auto', height: 'auto', maxWidth: '120px' }}
+                        className="w-24 h-32 object-cover rounded-lg"
                         onError={(e) => {
                           const target = e.target as HTMLImageElement;
                           target.style.display = 'none';
@@ -148,11 +147,11 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                     </div>
                     
                     {/* 説明（固定高さ） */}
-                    <div className="h-16 mb-3">
+                    <div className="h-20 mb-3">
                       {book.description && (
                         <p className="text-xs text-ios-gray-600 overflow-hidden h-full leading-relaxed">
-                          {book.description.length > 120 
-                            ? `${book.description.substring(0, 120)}...` 
+                          {book.description.length > 150 
+                            ? `${book.description.substring(0, 150)}...` 
                             : book.description}
                         </p>
                       )}
@@ -202,7 +201,7 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
             {/* 最後に「もっと見る」カード */}
             <div className="flex-shrink-0 w-64 snap-start">
               <Link href="/search">
-                <div className="h-[440px] bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 rounded-2xl border-2 border-dashed border-ios-blue/30 flex flex-col items-center justify-center hover:border-ios-blue transition-all duration-300 hover-lift">
+                <div className="h-[500px] bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 rounded-2xl border-2 border-dashed border-ios-blue/30 flex flex-col items-center justify-center hover:border-ios-blue transition-all duration-300 hover-lift">
                   <div className="text-4xl mb-4">🔍</div>
                   <p className="text-ios-blue font-semibold text-lg">もっと探す</p>
                   <p className="text-ios-gray-600 text-sm mt-2 text-center px-4">

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -150,8 +150,10 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                     {/* 説明（固定高さ） */}
                     <div className="h-12 mb-3">
                       {book.description && (
-                        <p className="text-xs text-ios-gray-600 overflow-hidden h-full leading-relaxed line-clamp-3">
-                          {book.description}
+                        <p className="text-xs text-ios-gray-600 overflow-hidden h-full leading-relaxed">
+                          {book.description.length > 80 
+                            ? `${book.description.substring(0, 80)}...` 
+                            : book.description}
                         </p>
                       )}
                     </div>

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -52,7 +52,7 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
           <h2 className="text-3xl font-bold text-ios-gray-800 mb-8">{title}</h2>
           <div className="flex gap-4 overflow-hidden">
             {Array.from({ length: count }).map((_, index) => (
-              <div key={index} className="flex-shrink-0 w-64 h-96 bg-ios-gray-100 rounded-2xl animate-pulse"></div>
+              <div key={index} className="flex-shrink-0 w-64 h-[440px] bg-ios-gray-100 rounded-2xl animate-pulse"></div>
             ))}
           </div>
         </div>
@@ -89,7 +89,7 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                 className="flex-shrink-0 w-64 snap-start hover-lift"
                 style={{ animationDelay: `${index * 0.1}s` }}
               >
-                <div className="bg-white rounded-2xl shadow-ios hover:shadow-ios-lg transition-all duration-300 overflow-hidden flex flex-col h-96">
+                <div className="bg-white rounded-2xl shadow-ios hover:shadow-ios-lg transition-all duration-300 overflow-hidden flex flex-col h-[440px]">
                   {/* 書籍画像 */}
                   <div className="w-full h-40 bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 flex items-center justify-center overflow-hidden">
                     {book.cover_image_url ? (
@@ -148,11 +148,11 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                     </div>
                     
                     {/* 説明（固定高さ） */}
-                    <div className="h-12 mb-3">
+                    <div className="h-16 mb-3">
                       {book.description && (
                         <p className="text-xs text-ios-gray-600 overflow-hidden h-full leading-relaxed">
-                          {book.description.length > 80 
-                            ? `${book.description.substring(0, 80)}...` 
+                          {book.description.length > 120 
+                            ? `${book.description.substring(0, 120)}...` 
                             : book.description}
                         </p>
                       )}
@@ -202,7 +202,7 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
             {/* 最後に「もっと見る」カード */}
             <div className="flex-shrink-0 w-64 snap-start">
               <Link href="/search">
-                <div className="h-96 bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 rounded-2xl border-2 border-dashed border-ios-blue/30 flex flex-col items-center justify-center hover:border-ios-blue transition-all duration-300 hover-lift">
+                <div className="h-[440px] bg-gradient-to-br from-ios-blue/10 to-ios-purple/10 rounded-2xl border-2 border-dashed border-ios-blue/30 flex flex-col items-center justify-center hover:border-ios-blue transition-all duration-300 hover-lift">
                   <div className="text-4xl mb-4">🔍</div>
                   <p className="text-ios-blue font-semibold text-lg">もっと探す</p>
                   <p className="text-ios-gray-600 text-sm mt-2 text-center px-4">

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -176,10 +176,9 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                           href={book.amazon_link}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex-1 bg-ios-blue text-white text-center py-2 px-3 rounded-lg text-xs font-medium hover:bg-ios-blue/90 transition-colors relative"
+                          className="flex-1 bg-ios-blue text-white text-center py-2 px-3 rounded-lg text-xs font-medium hover:bg-ios-blue/90 transition-colors"
                         >
-                          <span className="block">Amazon</span>
-                          <span className="text-[10px] opacity-80">PR</span>
+                          Amazon (PR)
                         </Link>
                         {book.summary_link && (
                           <Link

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -176,9 +176,10 @@ export default function BookSlider({ title, subtitle, count = 8 }: BookSliderPro
                           href={book.amazon_link}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex-1 bg-ios-blue text-white text-center py-2 px-3 rounded-lg text-xs font-medium hover:bg-ios-blue/90 transition-colors"
+                          className="flex-1 bg-ios-blue text-white text-center py-2 px-3 rounded-lg text-xs font-medium hover:bg-ios-blue/90 transition-colors relative"
                         >
-                          Amazon
+                          <span className="block">Amazon</span>
+                          <span className="text-[10px] opacity-80">PR</span>
                         </Link>
                         {book.summary_link && (
                           <Link


### PR DESCRIPTION
Improve top page text visibility and add "PR" notation to all Amazon links.

The top page text "たった1分で、あなたの人生を変える一冊に出会えるかもしれません。" was previously `opacity-90`, making it difficult to read. This change enhances readability. Additionally, "PR" notation has been added to all Amazon affiliate links to clearly distinguish them as promotional content, addressing the user's request for better transparency.

---
<a href="https://cursor.com/background-agent?bcId=bc-82899a84-e0a8-457d-ba88-9f5dbaf44f9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82899a84-e0a8-457d-ba88-9f5dbaf44f9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

