### PR TITLE
Remove duplicate ranked books and debug cause

### DIFF
--- a/src/components/RankingSlider.tsx
+++ b/src/components/RankingSlider.tsx
@@ -46,7 +46,35 @@ export default function RankingSlider({ title, subtitle }: RankingSliderProps) {
           return;
         }
         
-        setBooks(data);
+        // 重複排除処理: Amazonリンクが同一の書籍は最新のもののみを表示
+        const deduplicatedBooks = data.reduce((acc, book) => {
+          const existingIndex = acc.findIndex(existing => existing.amazon_link === book.amazon_link);
+          
+          if (existingIndex === -1) {
+            // 新しい書籍を追加
+            acc.push(book);
+          } else {
+            // 既存の書籍と比較して、より新しいものを採用
+            const existing = acc[existingIndex];
+            const bookCreatedAt = new Date(book.created_at);
+            const existingCreatedAt = new Date(existing.created_at);
+            
+            if (bookCreatedAt > existingCreatedAt) {
+              acc[existingIndex] = book; // より新しい書籍で置き換え
+            }
+          }
+          
+          return acc;
+        }, [] as RankingBook[]);
+        
+        console.log(`重複排除前: ${data.length}件, 重複排除後: ${deduplicatedBooks.length}件`);
+        if (data.length !== deduplicatedBooks.length) {
+          console.log('重複排除された書籍:', data.filter(book => 
+            !deduplicatedBooks.some(dedupe => dedupe.id === book.id)
+          ).map(book => book.title));
+        }
+        
+        setBooks(deduplicatedBooks);
         
       } catch (err) {
         console.error('ランキング書籍取得エラー:', err);


### PR DESCRIPTION
Implement frontend deduplication for ranking books by Amazon link and add admin tools for duplicate resolution to prevent duplicate display.

The frontend `RankingSlider` previously only filtered by `is_visible=true`, allowing multiple entries for the same book (identified by `amazon_link`) to appear if they were all marked visible. This occurred when the same book was registered from different ranking sources. The new frontend logic ensures only the latest entry for a given Amazon link is displayed, while the admin page now offers better visibility into these duplicates and a manual tool to resolve them by setting older entries to `is_visible=false` in the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef379c75-83d2-4e65-afb2-0cd9247e65c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef379c75-83d2-4e65-afb2-0cd9247e65c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

